### PR TITLE
chore(deps): group major updates into the existing dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,6 @@ updates:
       dependencies:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -27,4 +24,3 @@ updates:
     groups:
       actions:
         patterns: ["*"]
-        update-types: ["minor", "patch"]


### PR DESCRIPTION
Removes the `minor`/`patch` `update-types` filter from every `groups:` entry so major bumps join the grouped PR instead of opening standalone PRs. Result: one PR per ecosystem per repo. `ignore:` rules are untouched.